### PR TITLE
Add orchestrator contract schema and reference docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- Run `pytest` after making changes.
+- When creating or modifying orchestrator contracts, follow the schema in `orchestrator_contracts/contract_schema.json`.

--- a/orchestrator_contracts/contract_schema.json
+++ b/orchestrator_contracts/contract_schema.json
@@ -1,0 +1,7 @@
+{
+  "module": "analytics_engine",
+  "agent": "data_collector",
+  "allowed_files": ["config.yaml", "data/input.csv"],
+  "required_endpoints": ["GET /health", "POST /execute"],
+  "status": "draft"
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+# Plan
+
+## Contract Creation
+- Use `orchestrator_contracts/contract_schema.json` as the template for new contracts.
+- Each contract must define `module`, `agent`, `allowed_files`, `required_endpoints`, and `status`.


### PR DESCRIPTION
## Summary
- add `orchestrator_contracts/contract_schema.json` defining module, agent, allowed_files, required_endpoints, and status
- document contract schema usage in AGENTS guidelines
- outline contract creation plan referencing the schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e4d90e2588333b7a5e1f5b04ba71f