### PR TITLE
chore: configure pre-commit with black and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # 7taps-analytics
 Importing xAPI data from 7taps and doing magical stuff with it
+
+## Development
+
+This project uses [pre-commit](https://pre-commit.com/) to enforce formatting with [Black](https://black.readthedocs.io/en/stable/) and import sorting with [isort](https://pycqa.github.io/isort/).
+
+Install the hook:
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+Run the configured checks on any files you modify before committing:
+
+```
+pre-commit run --files <changed files>
+```
+
+Alternatively, rely on the Git hook by simply running `git commit` after installing pre-commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
## Summary
- add pre-commit config to run Black and isort
- configure Black and isort settings in pyproject
- document pre-commit usage in README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yml pyproject.toml --config .pre-commit-config.yml`

------
https://chatgpt.com/codex/tasks/task_e_688e4d97c5e4833389d37485b4843227